### PR TITLE
Use docs-style layout for standard and guidance detail pages

### DIFF
--- a/_includes/layouts/default.html
+++ b/_includes/layouts/default.html
@@ -6,22 +6,6 @@
       <div class="row">
         <div class="col-12">
           <div id="main-content">
-            {% if isStandard %}
-              <div class="mb-4">
-                <a href="/" class="btn btn-primary-outline">
-                  <i class="fa-solid fa-certificate" aria="hidden"></i>
-                  Standard
-                </a>
-              </div>
-            {% endif %}
-            {% if isGuidance %}
-              <div class="mb-4">
-                <a href="/guidance" class="btn btn-primary-outline">
-                  <i class="fa-solid fa-scroll" aria="hidden"></i>
-                  Guidance
-                </a>
-              </div>
-            {% endif %}
             {% if title %}
               <h1 class="display-5">{{ title | safe }}</h1>
             {% endif %}

--- a/_includes/layouts/docs.html
+++ b/_includes/layouts/docs.html
@@ -1,0 +1,43 @@
+{% include "header.html" %}
+{% include "nav.html" %}
+<main id="main-content">
+  <article>
+    <div class="container-fluid mt-3">
+      <div class="row g-4">
+        <div class="col-12 col-md-8 col-lg-9">
+          <div id="post">
+            {% if isStandard %}
+              <div class="mb-4">
+                <a href="/" class="btn btn-primary-outline">
+                  <i class="fa-solid fa-certificate" aria="hidden"></i>
+                  Standard
+                </a>
+              </div>
+            {% endif %}
+            {% if isGuidance %}
+              <div class="mb-4">
+                <a href="/guidance" class="btn btn-primary-outline">
+                  <i class="fa-solid fa-scroll" aria="hidden"></i>
+                  Guidance
+                </a>
+              </div>
+            {% endif %}
+            {% if title %}
+              <h1 class="display-5 pt-3 pb-2">{{ title | safe }}</h1>
+            {% endif %}
+            {% if description %}
+              <p class="lead fs-4 pb-3 mb-4 border-bottom">{{ description | safe }}</p>
+            {% endif %}
+            <div class="post">
+              {{ content | safe }}
+            </div>
+          </div>
+        </div>
+        <div class="col-12 col-md-4 col-lg-3">
+          {% include "toc.html" %}
+        </div>
+      </div>
+    </div>
+  </article>
+</main>
+{% include "footer.html" %}

--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -1,0 +1,27 @@
+<div class="d-none js-on-this-page">
+  <p class="border-bottom pb-3">On this page</p>
+  <ul class="nav flex-column">
+  </ul>
+</div>
+<script>
+  const tocContainer = document.querySelector('.js-on-this-page ul');
+  if (tocContainer) {
+    const headings = document.querySelectorAll('#post h2, #post h3');
+    if (headings.length > 0) {
+      headings.forEach(function(heading) {
+        const li = document.createElement('li');
+        li.className = 'mb-2 small';
+        if (heading.tagName === 'H3') {
+          li.classList.add('ms-3');
+        }
+        const a = document.createElement('a');
+        a.href = '#' + heading.id;
+        a.textContent = heading.textContent.replace(/\s+/g, ' ').trim();
+        li.appendChild(a);
+        tocContainer.appendChild(li);
+      });
+      document.querySelector('.js-on-this-page').classList.add('d-md-block');
+      document.querySelector('.js-on-this-page').classList.remove('d-none');
+    }
+  }
+</script>

--- a/content/docs/guidance.njk
+++ b/content/docs/guidance.njk
@@ -1,5 +1,5 @@
 ---
-layout: layouts/default.html
+layout: layouts/docs.html
 date: 2025-04-30
 modified: 2025-04-30
 author: ScanGov
@@ -21,72 +21,64 @@ topics:
   - Guidance
 ---
 
-<div class="container">
-  <div class="row">
-    <div class="col-12 col-sm-12 col-md-8 col-lg-8 col-xxl-8 post">
-      {% if guide.audio %}
-      <div class="border mb-4 px-4 py-2 shadow">
-          <h2 class="h4 my-0 py-3">Listen
-            <i class="fa-solid fa-volume-high"></i>
-          </h2>
-          <p class="pb-0 small text-secondary mb-0 pb-3">A podcast overview related to {{ guide.displayName }} made with Google NotebookLM.</p>
-          <script src="/js/plyr.js"></script>
-          <div tabindex="0" class="plyr plyr--full-ui plyr--audio plyr--html5 plyr--paused plyr--stopped">
-            <audio id="player">
-              <source src="{{ guide.audio }}" type="audio/mp3">
-            </audio>
-          </div>
-          <script>
-            const plyr = new Plyr('#player', {
-              controls: [
-                'play',
-                'progress',
-                'current-time',
-                'duration',
-                'mute',
-                'volume'
-              ]
-            });
-          </script>
-        </div>
-      {% endif %}
-      
-      <h2>Indicators</h2>
-      <ul class="list-inline pt-3">
-        {% for item in guide.topics %}
-          <li class="list-inline-item mr-1 mb-3">
-            <a href="/{{ item }}" class="btn btn-primary-outline">
-              <i class="fa-solid fa-{{ audits[item].icon }}"></i>
-              {{ audits[item].displayName }}
-            </a>
-          </li>
-        {% endfor %}
-      </ul>
-
-      {% if guide.about.title %}
-        <h2>{{ guide.about.title }}</h2>
-        {{ guide.about.content | safe }}
-      {% endif %}
-      
-      {% if guide.links %}
-        <h2>Links</h2>
-        <ul>
-        {% for item in guide.links %}
-          <li><a href="{{ item.link }}">{{ item.text }}</a></li>
-        {% endfor %}
-        </ul>
-      {% endif %}
-
-      <h2>Standards</h2>
-      <ul>
-        {% for item in guide.standards %}
-          <li>
-            <a href="{{ item.url.replace('https://standards.scangov.org','') }}">{{ item.displayName }}</a>
-          </li>
-        {% endfor %}
-      </ul>
-
+{% if guide.audio %}
+<div class="border mb-4 px-4 py-2 shadow">
+    <h2 class="h4 my-0 py-3">Listen
+      <i class="fa-solid fa-volume-high"></i>
+    </h2>
+    <p class="pb-0 small text-secondary mb-0 pb-3">A podcast overview related to {{ guide.displayName }} made with Google NotebookLM.</p>
+    <script src="/js/plyr.js"></script>
+    <div tabindex="0" class="plyr plyr--full-ui plyr--audio plyr--html5 plyr--paused plyr--stopped">
+      <audio id="player">
+        <source src="{{ guide.audio }}" type="audio/mp3">
+      </audio>
     </div>
-    <div class="col-12 col-sm-12 col-md-4 col-lg-4 col-xxl-4 js-on-this-page">
-      <!-- on this page links will be put here in footer js -->
-    </div>
+    <script>
+      const plyr = new Plyr('#player', {
+        controls: [
+          'play',
+          'progress',
+          'current-time',
+          'duration',
+          'mute',
+          'volume'
+        ]
+      });
+    </script>
+  </div>
+{% endif %}
+
+<h2>Indicators</h2>
+<ul class="list-inline pt-3">
+  {% for item in guide.topics %}
+    <li class="list-inline-item mr-1 mb-3">
+      <a href="/{{ item }}" class="btn btn-primary-outline">
+        <i class="fa-solid fa-{{ audits[item].icon }}"></i>
+        {{ audits[item].displayName }}
+      </a>
+    </li>
+  {% endfor %}
+</ul>
+
+{% if guide.about.title %}
+  <h2>{{ guide.about.title }}</h2>
+  {{ guide.about.content | safe }}
+{% endif %}
+
+{% if guide.links %}
+  <h2>Links</h2>
+  <ul>
+  {% for item in guide.links %}
+    <li><a href="{{ item.link }}">{{ item.text }}</a></li>
+  {% endfor %}
+  </ul>
+{% endif %}
+
+<h2>Standards</h2>
+<ul>
+  {% for item in guide.standards %}
+    <li>
+      <a href="{{ item.url.replace('https://standards.scangov.org','') }}">{{ item.displayName }}</a>
+    </li>
+  {% endfor %}
+</ul>

--- a/content/docs/standard.njk
+++ b/content/docs/standard.njk
@@ -1,5 +1,5 @@
 ---
-layout: layouts/default.html
+layout: layouts/docs.html
 date: 2025-02-01
 modified: 2025-03-17
 author: ScanGov
@@ -22,117 +22,109 @@ topics:
   - Standards
 ---
 
-<div class="container">
-  <div class="row">
-    <div class="col-12 col-sm-12 col-md-8 col-lg-8 col-xxl-8 post">
-      {% if docpage.relatedLinks.audio %}
-      <div class="border mb-4 px-4 py-2 shadow">
-          <h2 class="h4 my-0 py-3">Listen
-            <i class="fa-solid fa-volume-high"></i>
-          </h2>
-          <p class="pb-0 small text-secondary mb-0 pb-3">A podcast overview related to {{ docpage.displayName }} made with Google NotebookLM.</p>
-          <script src="/js/plyr.js"></script>
-          <div tabindex="0" class="plyr plyr--full-ui plyr--audio plyr--html5 plyr--paused plyr--stopped">
-            <audio id="player">
-              <source src="{{ docpage.relatedLinks.audio }}" type="audio/mp3">
-            </audio>
-          </div>
-          <script>
-            const plyr = new Plyr('#player', {
-              controls: [
-                'play',
-                'progress',
-                'current-time',
-                'duration',
-                'mute',
-                'volume'
-              ]
-            });
-          </script>
-        </div>
-      {% endif %}
-
-      <h2>Indicators</h2>
-
-      <ul class="list-inline pt-3">
-        <li class="list-inline-item mr-1 mb-3">
-            <a href="/{{ docpage.topic }}" class="btn btn-primary-outline">
-              <i class="fa-solid fa-{{ docpage.topicIcon }}"></i>
-              {{ audits[docpage.topic].displayName }}
-            </a>
-        </li>
-      </ul>
-
-      <h2>Impact</h2>
-
-      <p class="small">(How <a href="https://scangov.com">ScanGov</a> measures tasklist priorities.)</small></p>
-
-      <div class="bolts mt-3 mb-3">
-        {% set taskNum = docpage.impact %}
-        {% if taskNum == 0 %}
-          {% set taskNum = 1 %}
-        {% endif %}
-        {% for i in range(taskNum) %}
-          <i class="fa-solid fa-bolt"></i>
-        {% endfor %}
-      </div>
-
-      {% if docpage.sections.about.title %}
-        <h2>{{ docpage.sections.about.title }}</h2>
-        {{ docpage.sections.about.content | safeHtml | safe }}
-      {% endif %}
-
-      <h2>Why it's important</h2>
-      <p>{{ docpage.why | escape }}</p>
-
-      {% if docpage.userStories %}
-      <h2>User stories</h2>
-      {% for item in docpage.userStories %}
-        <blockquote>{{ item.title }}</blockquote>
-      {% endfor %}
-      {% endif %}
-
-      {% if docpage.sections.code %}
-        <h2>{{ docpage.sections.code.title }}</h2>
-        {{ docpage.sections.code.content | safe }}
-      {% endif %}
-
-      <h2>Error</h2>
-      <p class="small mb-3 pb-0">(ScanGov messaging when a site fails a standard)</small></p>
-
-      <blockquote>
-      {{ docpage.error | escape }}
-      </blockquote>
-
-      {% if docpage.sections.example %}
-        <h2>{{ docpage.sections.example.title }}</h2>
-        {{ docpage.sections.example.content | safe }}
-      {% endif %}
-
-      {% if docpage.guidance %}
-      <h2>Guidance</h2>
-      <ul>
-      {% for item in docpage.guidance %}
-        <li><a href="{{ item.url }}">{{ item.displayName }}</a></li>
-      {% endfor %}
-      </ul>
-      {% endif %}
-
-      {% if docpage.sections.links %}
-        <h2>{{ docpage.sections.links.title }}</h2>
-        {{ docpage.sections.links.content | safe }}
-      {% endif %}
-
-      {% if docpage.relatedLinks %}
-      <h2>Related</h2>
-      <ul>
-      {% for item in audits[docpage.topic].attributes %}
-        <li><a href="/{{ item.key.toLowerCase() }}">{{ item.displayName | escape }}</a></li>
-      {% endfor %}
-      </ul>
-      {% endif %}
-
+{% if docpage.relatedLinks.audio %}
+<div class="border mb-4 px-4 py-2 shadow">
+    <h2 class="h4 my-0 py-3">Listen
+      <i class="fa-solid fa-volume-high"></i>
+    </h2>
+    <p class="pb-0 small text-secondary mb-0 pb-3">A podcast overview related to {{ docpage.displayName }} made with Google NotebookLM.</p>
+    <script src="/js/plyr.js"></script>
+    <div tabindex="0" class="plyr plyr--full-ui plyr--audio plyr--html5 plyr--paused plyr--stopped">
+      <audio id="player">
+        <source src="{{ docpage.relatedLinks.audio }}" type="audio/mp3">
+      </audio>
     </div>
-    <div class="col-12 col-sm-12 col-md-4 col-lg-4 col-xxl-4 js-on-this-page">
-      <!-- on this page links will be put here in footer js -->
-    </div>
+    <script>
+      const plyr = new Plyr('#player', {
+        controls: [
+          'play',
+          'progress',
+          'current-time',
+          'duration',
+          'mute',
+          'volume'
+        ]
+      });
+    </script>
+  </div>
+{% endif %}
+
+<h2>Indicators</h2>
+
+<ul class="list-inline pt-3">
+  <li class="list-inline-item mr-1 mb-3">
+      <a href="/{{ docpage.topic }}" class="btn btn-primary-outline">
+        <i class="fa-solid fa-{{ docpage.topicIcon }}"></i>
+        {{ audits[docpage.topic].displayName }}
+      </a>
+  </li>
+</ul>
+
+<h2>Impact</h2>
+
+<p class="small">(How <a href="https://scangov.com">ScanGov</a> measures tasklist priorities.)</small></p>
+
+<div class="bolts mt-3 mb-3">
+  {% set taskNum = docpage.impact %}
+  {% if taskNum == 0 %}
+    {% set taskNum = 1 %}
+  {% endif %}
+  {% for i in range(taskNum) %}
+    <i class="fa-solid fa-bolt"></i>
+  {% endfor %}
+</div>
+
+{% if docpage.sections.about.title %}
+  <h2>{{ docpage.sections.about.title }}</h2>
+  {{ docpage.sections.about.content | safeHtml | safe }}
+{% endif %}
+
+<h2>Why it's important</h2>
+<p>{{ docpage.why | escape }}</p>
+
+{% if docpage.userStories %}
+<h2>User stories</h2>
+{% for item in docpage.userStories %}
+  <blockquote>{{ item.title }}</blockquote>
+{% endfor %}
+{% endif %}
+
+{% if docpage.sections.code %}
+  <h2>{{ docpage.sections.code.title }}</h2>
+  {{ docpage.sections.code.content | safe }}
+{% endif %}
+
+<h2>Error</h2>
+<p class="small mb-3 pb-0">(ScanGov messaging when a site fails a standard)</small></p>
+
+<blockquote>
+{{ docpage.error | escape }}
+</blockquote>
+
+{% if docpage.sections.example %}
+  <h2>{{ docpage.sections.example.title }}</h2>
+  {{ docpage.sections.example.content | safe }}
+{% endif %}
+
+{% if docpage.guidance %}
+<h2>Guidance</h2>
+<ul>
+{% for item in docpage.guidance %}
+  <li><a href="{{ item.url }}">{{ item.displayName }}</a></li>
+{% endfor %}
+</ul>
+{% endif %}
+
+{% if docpage.sections.links %}
+  <h2>{{ docpage.sections.links.title }}</h2>
+  {{ docpage.sections.links.content | safe }}
+{% endif %}
+
+{% if docpage.relatedLinks %}
+<h2>Related</h2>
+<ul>
+{% for item in audits[docpage.topic].attributes %}
+  <li><a href="/{{ item.key.toLowerCase() }}">{{ item.displayName | escape }}</a></li>
+{% endfor %}
+</ul>
+{% endif %}


### PR DESCRIPTION
Add fluid container with gutter spacing and a working 'on this page' table of contents, replacing the dead js-on-this-page placeholder.