### PR TITLE
Sync scangov.css from components

### DIFF
--- a/public/css/scangov.css
+++ b/public/css/scangov.css
@@ -1431,11 +1431,6 @@ a.card {
 
 /* Forms */
 
-form button[type="submit"],
-form input[type="submit"] {
-    margin-bottom: 2rem;
-}
-
 td form button[type="submit"],
 td form input[type="submit"] {
     margin-bottom: 0;
@@ -1485,6 +1480,25 @@ input[type="submit"] {
 
 .progress {
     height: 6px;
+}
+
+.border-list-item {
+    border: 1px solid var(--bs-border-color);
+    padding: 0.5rem;
+}
+
+.border-list-item:first-child {
+    border-top-left-radius: var(--bs-border-radius);
+    border-top-right-radius: var(--bs-border-radius);
+}
+
+.border-list-item:last-child {
+    border-bottom-left-radius: var(--bs-border-radius);
+    border-bottom-right-radius: var(--bs-border-radius);
+}
+
+.border-list-item:hover {
+    background-color: rgba(var(--bs-emphasis-color-rgb), 0.075);
 }
 
 /* SVG */
@@ -2074,6 +2088,16 @@ td a:hover .fa-circle-info {
     color: var(--bs-body-color) !important;
 }
 
+.js-sidenav a .fa-circle-question,
+.js-sidenav a:hover .fa-circle-question {
+    color: #97d4ea !important;
+}
+
+.js-sidenav a .fa-circle-info,
+.js-sidenav a:hover .fa-circle-info {
+    color: #b8d293 !important;
+}
+
 .fa-triangle-exclamation {
     color: #f4a0a0;
 }
@@ -2606,6 +2630,16 @@ a .fa-up-right-from-square {
 [data-bs-theme=light] a .fa-circle-info,
 [data-bs-theme=light] a:hover .fa-circle-info {
     color: inherit !important;
+}
+
+[data-bs-theme=light] .js-sidenav a .fa-circle-question,
+[data-bs-theme=light] .js-sidenav a:hover .fa-circle-question {
+    color: #1a6fa0 !important;
+}
+
+[data-bs-theme=light] .js-sidenav a .fa-circle-info,
+[data-bs-theme=light] .js-sidenav a:hover .fa-circle-info {
+    color: #2d7a3a !important;
 }
 
 [data-bs-theme=light] .fa-triangle-exclamation {


### PR DESCRIPTION
Picks up sidebar icon-color fixes and sticky-footer layout. Layout file sync excluded — standards' docs.html has its own customizations a blind components sync would clobber (see PR #148, closed unmerged).