### PR TITLE
Upgrade sharp to fix Dependabot alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "html-minifier-terser": "^7.2.0",
     "purgecss": "^7.0.2"
   },
+  "overrides": {
+    "sharp": "^0.35.3"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
Add npm override for sharp (^0.35.3) since @11ty/eleventy-img still caps its own range below 0.34.0.