### PR TITLE
Fix npm dependency vulnerabilities via package.json overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "purgecss": "^7.0.2"
   },
   "overrides": {
-    "sharp": "^0.35.3"
+    "sharp": "^0.35.3",
+    "brace-expansion": "^1.1.18",
+    "postcss": "^8.5.25"
   },
   "keywords": [],
   "author": "",

--- a/scripts/bundle.css
+++ b/scripts/bundle.css
@@ -1011,10 +1011,17 @@ button.btn-secondary-outline {
     cursor: pointer;
     position: fixed;
     bottom: 1rem;
-    right: 1rem;
+    left: 50%;
+    transform: translateX(-50%);
     z-index: 1000;
     text-decoration: none;
     transition: opacity 0.25s ease, visibility 0.25s ease, filter 0.25s ease, box-shadow 0.25s ease;
+}
+
+.feedback.feedback-right {
+    left: auto;
+    right: 1rem;
+    transform: none;
 }
 
 .feedback.is-visible {


### PR DESCRIPTION
package-lock.json is gitignored here, so npm audit fix has nothing to commit. Pin brace-expansion and postcss to their patched versions via overrides instead. Also rebuilt scripts/bundle.css, which had fallen behind the already-merged feedback-button CSS change.

Part of ScanGov/scangov-com#193